### PR TITLE
Add support for fullwidth characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var util = require("./util")
 module.exports = blit
 
 // Applies 'lines' to 'screen' at coordinates x/y
@@ -23,46 +24,11 @@ function blit (screen, lines, x, y) {
 // String, String -> String
 function mergeString (src, string, x) {
   var res = src
-  var extraCharsNeeded = (x + strlenAnsi(string)) - strlenAnsi(src)
+  var extraCharsNeeded = (x + util.strlenAnsi(string)) - util.strlenAnsi(src)
   if (extraCharsNeeded > 0) {
     res += (new Array(extraCharsNeeded).fill(' ')).join('')
   }
 
-  return sliceAnsi(res, 0, x) + string + sliceAnsi(res, x + strlenAnsi(string))
+  return util.sliceAnsi(res, 0, x) + string + util.sliceAnsi(res, x + util.strlenAnsi(string))
 }
 
-// Like String#slice, but taking ANSI codes into account
-function sliceAnsi (str, from, to) {
-  var len = 0
-  var insideCode = false
-  var res = ''
-  to = (to === undefined) ? str.length : to
-
-  for (var i=0; i < str.length; i++) {
-    var chr = str.charAt(i)
-    if (chr === '\033') insideCode = true
-    if (!insideCode) len++
-    if (chr === 'm' && insideCode) insideCode = false
-
-    if (len > from && len <= to) {
-      res += chr
-    }
-  }
-
-  return res
-}
-
-// Length of 'str' sans ANSI codes
-function strlenAnsi (str) {
-  var len = 0
-  var insideCode = false
-
-  for (var i=0; i < str.length; i++) {
-    var chr = str.charAt(i)
-    if (chr === '\033') insideCode = true
-    if (!insideCode) len++
-    if (chr === 'm' && insideCode) insideCode = false
-  }
-
-  return len
-}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var util = require("./util")
+var util = require('./util')
 module.exports = blit
 
 // Applies 'lines' to 'screen' at coordinates x/y
@@ -13,7 +13,7 @@ function blit (screen, lines, x, y) {
   }
 
   // patch lines
-  for (var i=y; i < y + lines.length; i++) {
+  for (var i = y; i < y + lines.length; i++) {
     tmp[i] = mergeString(tmp[i], lines[i - y], x)
   }
 
@@ -31,4 +31,3 @@ function mergeString (src, string, x) {
 
   return util.sliceAnsi(res, 0, x) + string + util.sliceAnsi(res, x + util.strlenAnsi(string))
 }
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "standard"
   },
   "keywords": [],
-  "dependencies": {},
+  "dependencies": {
+    "is-fullwidth-code-point": "^3.0.0"
+  },
   "devDependencies": {
     "standard": "~10.0.0"
   },

--- a/util.js
+++ b/util.js
@@ -1,0 +1,42 @@
+module.exports = { sliceAnsi, strlenAnsi }
+var isFullwidth = require("is-fullwidth-code-point")
+
+// Like String#slice, but taking ANSI codes into account
+function sliceAnsi (str, from, to) {
+  var len = 0
+  var insideCode = false
+  var res = ''
+  to = (to === undefined) ? str.length : to
+
+  for (var i=0; i < str.length; i++) {
+    var chr = str.charAt(i)
+    if (chr === '\033') insideCode = true
+    if (!insideCode) len += chrlen(chr)
+    if (chr === 'm' && insideCode) insideCode = false
+
+    if (len > from && len <= to) {
+      res += chr
+    }
+  }
+
+  return res
+}
+
+// Length of 'str' sans ANSI codes
+function strlenAnsi (str) {
+  var len = 0
+  var insideCode = false
+
+  for (var i=0; i < str.length; i++) {
+    var chr = str.charAt(i)
+    if (chr === '\033') insideCode = true
+    if (!insideCode) len += chrlen(chr)
+    if (chr === 'm' && insideCode) insideCode = false
+  }
+
+  return len
+}
+
+function chrlen (chr) {
+    return isFullwidth(chr.codePointAt(0)) ? 2 : 1
+}


### PR DESCRIPTION
This PR fixes #1. The issue was that fullwidth characters take up twice the space as halfwidth characters (i.e. ascii or most European character sets.)

I've introduced the dependency https://github.com/sindresorhus/is-fullwidth-code-point, which keeps track of which codepoints are fullwidth.

As part of testing and developing, I also broke out the utility methods into a `util.js`. I can revert that change and throw everything into `index.js` if that feels better @noffle. 

Anyway this should fix one part of the rendering issues in the terminal client for cabal, as described in https://github.com/cabal-club/cabal/issues/32. I have a fix for the other part too, but it isn't related to txt-blit.